### PR TITLE
Fix incorrect if check in workflow.

### DIFF
--- a/.github/workflows/generate-codes.yml
+++ b/.github/workflows/generate-codes.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Commit and push changed files
         # Only do this if workflow was started from manual dispatch:
-        if: "${{ github.event.name == 'workflow_dispatch' }}"
+        if: "${{ github.event_name == 'workflow_dispatch' }}"
         # We want commits to be attributed to the use initiating the workflow
         env:
           GIT_USER_NAME: "${{ github.actor }}"


### PR DESCRIPTION
So that the "commit and push changed files" step runs when generate-codes.yml is triggered manually.