### PR TITLE
Fix issue 110

### DIFF
--- a/packages/@navikt/diagnosekoder/src/ICD10.ts
+++ b/packages/@navikt/diagnosekoder/src/ICD10.ts
@@ -1,4 +1,4 @@
-import icd10Json from './ICD10.json' assert {type: 'json'};
+import icd10Json from './ICD10.json' with {type: 'json'};
 import {castToIcd10Diagnosekode, type ICD10Diagnosekode} from "./ICD10Diagnosekode.js";
 
 export const ICD10: ReadonlyArray<ICD10Diagnosekode> = icd10Json.map(castToIcd10Diagnosekode)

--- a/packages/@navikt/diagnosekoder/src/ICPC2.ts
+++ b/packages/@navikt/diagnosekoder/src/ICPC2.ts
@@ -1,4 +1,4 @@
 import icpc2Json from './ICPC2.json' with {type: 'json'};
-import {type ICPC2Diagnosekode, toIcpc2Diagnosekode} from "./ICPC2Diagnosekode.js";
+import { castToIcpc2Diagnosekode, type ICPC2Diagnosekode } from "./ICPC2Diagnosekode.js";
 
-export const ICPC2: ReadonlyArray<ICPC2Diagnosekode> = icpc2Json.map(toIcpc2Diagnosekode)
+export const ICPC2: ReadonlyArray<ICPC2Diagnosekode> = icpc2Json.map(castToIcpc2Diagnosekode)

--- a/packages/@navikt/diagnosekoder/src/ICPC2.ts
+++ b/packages/@navikt/diagnosekoder/src/ICPC2.ts
@@ -1,4 +1,4 @@
-import icpc2Json from './ICPC2.json' assert {type: 'json'};
+import icpc2Json from './ICPC2.json' with {type: 'json'};
 import {type ICPC2Diagnosekode, toIcpc2Diagnosekode} from "./ICPC2Diagnosekode.js";
 
 export const ICPC2: ReadonlyArray<ICPC2Diagnosekode> = icpc2Json.map(toIcpc2Diagnosekode)

--- a/packages/@navikt/diagnosekoder/src/ICPC2Diagnosekode.ts
+++ b/packages/@navikt/diagnosekoder/src/ICPC2Diagnosekode.ts
@@ -25,3 +25,13 @@ export const toIcpc2Diagnosekode = (dk: Diagnosekode): ICPC2Diagnosekode => {
     validateIcpc2Diagnosekode(dk)
     return {...dk, [icpc2]: undefined}
 }
+
+/**
+ * Used when loading the generated json file to avoid performance overhead of validating it with toIcpc2Diagnosekode.
+ *
+ * No point in revalidating the json every time it is loaded, as long as toIcd2Diagnosekode is used in the generator
+ * when creating the json file.
+ *
+ * @param dk
+ */
+export const castToIcpc2Diagnosekode = (dk: Diagnosekode): ICPC2Diagnosekode => dk as ICPC2Diagnosekode


### PR DESCRIPTION
Use a typecast when returning ICPC2 codes from generated json file, instead of validating it each time. Just like it's already done for ICD10 codes.

No point in validating it each time, as long as it's validated when generated.

Closes #110 